### PR TITLE
Fix Out-of-Bounds Error in convertFromHistogram Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+/.idea


### PR DESCRIPTION
## Description 

This PR addresses an out-of-bounds error in the convertFromHistogram function. The error occurred when accessing histogram bucket bounds, leading to a mismatch in the number of generated time series. The fix ensures that the last bucket is correctly handled and the expected number of time series is generated.

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
